### PR TITLE
[#3] 시간 블록 섹션 뷰 제작

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "stylelint-config-prettier",
-    "stylelint-config-concentric-order",
     "stylelint-config-styled-components",
     "postcss-syntax",
     "postcss-html"

--- a/src/components/Day/TimeDragSection/TimeBlockSection.tsx
+++ b/src/components/Day/TimeDragSection/TimeBlockSection.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+import TimeBlocks from './TimeBlocks';
+
+interface TimeBlockSectionProps {
+  plans: string[];
+}
+
+function TimeBlockSection(props: TimeBlockSectionProps) {
+  const { plans } = props;
+  return (
+    <Styled.Root>
+      {plans.map((el) => (
+        <TimeBlocks key={el} />
+      ))}
+    </Styled.Root>
+  );
+}
+
+export default TimeBlockSection;
+
+const Styled = {
+  Root: styled.div`
+    display: flex;
+    position: absolute;
+    bottom: 4rem;
+    flex-direction: column;
+    gap: 1.2rem;
+    margin-left: 0.75rem;
+  `,
+};

--- a/src/components/Day/TimeDragSection/TimeBlocks.tsx
+++ b/src/components/Day/TimeDragSection/TimeBlocks.tsx
@@ -1,0 +1,40 @@
+import { getTimeArray } from 'src/utils/timeArray';
+import styled from 'styled-components';
+
+interface timeType {
+  hour: number;
+  min: number;
+}
+
+function TimeBlocks() {
+  const { timeArr } = getTimeArray();
+
+  return (
+    <Styled.Root>
+      {timeArr.map((el: timeType) => (
+        <Styled.Block key={`${el.hour}:${el.min}`} min={el.min} />
+      ))}
+    </Styled.Root>
+  );
+}
+
+export default TimeBlocks;
+
+const Styled = {
+  Root: styled.div`
+    display: flex;
+    width: fit-content;
+    /* margin-bottom: 1.2rem; */
+  `,
+  Block: styled.div<{ min: number }>`
+    display: flex;
+    flex-shrink: 0;
+    margin-right: ${({ min }) => (min === 45 ? '0.7rem' : '0.4rem')};
+    /* 아직 컬러 코드가 나오지 않아 나오면 pr수정하겠습니다. */
+    border: 1px solid #e3e6ea;
+    border-radius: 0.5px;
+    cursor: pointer;
+    width: 1.8rem;
+    height: 3.2rem;
+  `,
+};

--- a/src/components/Day/TimeDragSection/TimeBlocks.tsx
+++ b/src/components/Day/TimeDragSection/TimeBlocks.tsx
@@ -6,6 +6,8 @@ interface timeType {
   min: number;
 }
 
+const LAST_MINIT_OF_HOUR = 45;
+
 function TimeBlocks() {
   const { timeArr } = getTimeArray();
 
@@ -24,13 +26,11 @@ const Styled = {
   Root: styled.div`
     display: flex;
     width: fit-content;
-    /* margin-bottom: 1.2rem; */
   `,
   Block: styled.div<{ min: number }>`
     display: flex;
     flex-shrink: 0;
-    margin-right: ${({ min }) => (min === 45 ? '0.7rem' : '0.4rem')};
-    /* 아직 컬러 코드가 나오지 않아 나오면 pr수정하겠습니다. */
+    margin-right: ${({ min }) => (min === LAST_MINIT_OF_HOUR ? '0.7rem' : '0.4rem')};
     border: 1px solid #e3e6ea;
     border-radius: 0.5px;
     cursor: pointer;

--- a/src/components/Day/TimeDragSection/TimeLine.tsx
+++ b/src/components/Day/TimeDragSection/TimeLine.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import TimeBlockSection from './TimeBlockSection';
+
+interface LineWrapperStyledProps {
+  idx: number;
+  nowHour: number;
+  planNum: number;
+}
+
+function TimeLine() {
+  const [plans] = useState(['tempId1', 'tempId2', 'tempId3', 'tempId1']);
+  const ref = useRef<HTMLDivElement>(null);
+  const nowHour = new Date().getHours();
+
+  useEffect(() => {
+    if (ref.current) {
+      if (nowHour < 5) {
+        ref.current.scrollTo(0, 0);
+      } else if (nowHour < 17 && nowHour >= 4) {
+        ref.current.scrollTo(91 * (nowHour - 4), 0);
+      } else {
+        console.log(91 * (nowHour - 4));
+        ref.current.scrollTo(1200, 0);
+      }
+    }
+  }, []);
+
+  const getTimeLine = () => {
+    const hours = [];
+    for (let i = 0; i < 24; i++) {
+      hours.push(i);
+    }
+    return hours;
+  };
+
+  const hours = getTimeLine();
+
+  return (
+    <Styled.Wrapper>
+      <Styled.Shadow direction="left" planNum={plans.length} />
+      <Styled.Root ref={ref}>
+        <Styled.TimeLineWrapper>
+          {hours.map((el) => (
+            <Styled.LineWrapper key={el}>
+              <Styled.Hour idx={el} nowHour={nowHour}>
+                {el}
+              </Styled.Hour>
+              <Styled.Line planNum={plans.length} idx={el} nowHour={nowHour} />
+            </Styled.LineWrapper>
+          ))}
+        </Styled.TimeLineWrapper>
+        <TimeBlockSection plans={plans} />
+      </Styled.Root>
+      <Styled.Shadow direction="right" planNum={plans.length} />
+    </Styled.Wrapper>
+  );
+}
+
+export default TimeLine;
+
+const Styled = {
+  Root: styled.div`
+    display: flex;
+    position: relative;
+    padding-bottom: 4rem;
+    width: 109.8rem;
+    overflow-x: scroll;
+    ::-webkit-scrollbar {
+      appearance: none;
+      height: 0.6rem;
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: #0a42df;
+    }
+    ::-webkit-scrollbar-track {
+      background-color: #f8f9fb;
+    }
+  `,
+
+  Wrapper: styled.div`
+    display: flex;
+  `,
+
+  TimeLineWrapper: styled.div`
+    display: flex;
+    margin-left: -1.2rem;
+  `,
+
+  LineWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-right: 5.9rem;
+  `,
+
+  Hour: styled.div<Omit<LineWrapperStyledProps, 'planNum'>>`
+    display: flex;
+    color: ${({ idx, nowHour }) => (nowHour === idx ? '#ffffff' : '#b8b8b8')};
+    font-size: 1.4rem;
+    font-weight: 700;
+    width: ${({ idx, nowHour }) => (nowHour === idx ? '2.7rem' : '3.2rem')};
+    height: ${({ idx, nowHour }) => (nowHour === idx ? '2.7rem' : '3.2rem')};
+    margin-top: 0.9rem;
+    justify-content: center;
+    align-items: center;
+    ${({ idx, nowHour }) =>
+      nowHour === idx &&
+      'background-color:#0A42DF; border-radius:50%; margin:0.25rem; border:2px solid #ffffff; box-shadow: 0 0 0 2px #0A42DF; transform:'}
+  `,
+
+  Line: styled.div<LineWrapperStyledProps>`
+    margin-top: ${({ idx, nowHour }) => (nowHour === idx ? '-0.1rem' : '1rem')};
+    background-color: ${({ idx, nowHour }) => (nowHour === idx ? '#0A42DF' : '#e3e6ea')};
+    width: 0.1rem;
+    height: ${({ planNum, idx, nowHour }) =>
+      `${nowHour === idx ? 4.1 + 4.4 * planNum : 1.6 + 4.4 * planNum}rem`};
+  `,
+
+  Shadow: styled.div<{ planNum: number; direction: string }>`
+    margin-top: 4.2rem;
+    box-shadow: ${({ direction }) => (direction === 'left' ? '10px' : '-10px')} 0px 23px
+      rgb(0, 0, 0);
+    width: 0.01rem;
+    height: ${({ planNum }) => `${1.6 + 4.4 * planNum}rem`};
+  `,
+};

--- a/src/components/Day/TimeDragSection/TimeLine.tsx
+++ b/src/components/Day/TimeDragSection/TimeLine.tsx
@@ -9,8 +9,11 @@ interface LineWrapperStyledProps {
   planNum: number;
 }
 
+const ONE_HOUR_WIDTH = 91;
+const SCROLL_END_VAL = 1200;
+
 function TimeLine() {
-  const [plans] = useState(['tempId1', 'tempId2', 'tempId3', 'tempId1']);
+  const [plans] = useState(['tempId1', 'tempId2', 'tempId3', 'tempId4']);
   const ref = useRef<HTMLDivElement>(null);
   const nowHour = new Date().getHours();
 
@@ -19,10 +22,9 @@ function TimeLine() {
       if (nowHour < 5) {
         ref.current.scrollTo(0, 0);
       } else if (nowHour < 17 && nowHour >= 4) {
-        ref.current.scrollTo(91 * (nowHour - 4), 0);
+        ref.current.scrollTo(ONE_HOUR_WIDTH * (nowHour - 4), 0);
       } else {
-        console.log(91 * (nowHour - 4));
-        ref.current.scrollTo(1200, 0);
+        ref.current.scrollTo(SCROLL_END_VAL, 0);
       }
     }
   }, []);

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -12,7 +12,6 @@ const GlobalStyles = createGlobalStyle`
     width: 100%;
     height: 100%;
     font-size: 62.5%;
-    background-color: #F5F5F5;
   }
   body > div {
     height: 100%;

--- a/src/utils/timeArray.ts
+++ b/src/utils/timeArray.ts
@@ -1,0 +1,11 @@
+export const getTimeArray = () => {
+  const timeArr = [];
+
+  for (let i = 0; i < 96; i++) {
+    const time = { hour: Math.floor(i / 4), min: (i % 4) * 15 };
+
+    timeArr.push(time);
+  }
+
+  return { timeArr };
+};


### PR DESCRIPTION
## ✅ PR check list

- [x] 시간 당 타임라인 제작
- [x] 시간 블록 제작
- [x] 스크롤 커스텀 및 항상 보이게 고정
- [x] 현재 시간 표시 및 시간에 따른 스크롤 이동 구현

<br/>

## 📝 PR 요약
- 시간 배열을 util로 배열을 제작하여 map을 돌려 생성했습니다. 하나의 시간 블럭당 각 시간이 포함되어 있습니다. 시간은 15분 단위로 한 시간당 0분, 15분, 30분, 45분 존재합니다.
- 시간 블럭들을 타임라인 선 위에 absolute로 배치시켰습니다.
- 계획의 갯수에 따라 시간블럭이 늘어나도록 구성했습니다.
- 현재 시간에 프로그래스 바가 보여지도록 구현하였고, 현재시간으로 스크롤이 이동하도록 구현하였습니다.

<br/>

## 📌 변경 사항 및 주의 사항

- stylelint 에러로 인해 세팅을 변경하였습니다.
- 컬러코드가 나오지 않은 상태로 시작하여 추후 수정하겠습니다

<br/>