### PR TITLE
[#113][HOTFIX] 날짜 변수 로직변경 

### DIFF
--- a/src/components/Day/DayInfoSection/DateController.tsx
+++ b/src/components/Day/DayInfoSection/DateController.tsx
@@ -4,39 +4,33 @@ import { theme } from 'src/styles/theme';
 import { DayStorage, makeDateString } from 'src/utils/getDate';
 import styled from 'styled-components';
 
+const DEFAULT_DATE = 0;
+const PREV_DATE = -1;
+const NEXT_DATE = 1;
+const STANDARD_DATE = makeDateString(DEFAULT_DATE);
+
 function DateController() {
-  const DEFAULT_DATE = 0;
-  const PREV_DATE = -1;
-  const NEXT_DATE = 1;
-  const [changedDays, setChangedDays] = useState(0);
-  const [pivotDate, setPivotDate] = useState(makeDateString(DEFAULT_DATE));
   const router = useRouter();
-  const today = makeDateString(DEFAULT_DATE);
+  const [changedDays, setChangedDays] = useState(0);
 
   useEffect(() => {
-    const localCountingDays = Number(window.localStorage.getItem('changedDaysCount'));
-    const localPivotDate = window.localStorage.getItem('pivotDate');
+    const sessionCountingDays = Number(sessionStorage.getItem('changedDaysCount'));
 
-    if (!localPivotDate) {
-      window.localStorage.setItem('pivotDate', today);
-    }
-    if (localPivotDate) {
-      setPivotDate(localPivotDate);
-    }
-    if (localCountingDays) {
-      setChangedDays(localCountingDays);
-    }
+    sessionCountingDays
+      ? setChangedDays(sessionCountingDays)
+      : sessionStorage.setItem('changedDaysCount', DEFAULT_DATE.toString());
 
-    router.push(`/day/${DayStorage(pivotDate.slice(0, 10), localCountingDays)}`);
+    router.push(`/day/${DayStorage(STANDARD_DATE.slice(0, 10), sessionCountingDays)}`);
   }, []);
 
   useEffect(() => {
     moveToSelectedDate();
-    window.localStorage.setItem('changedDaysCount', changedDays.toString());
+    window.sessionStorage.setItem('changedDaysCount', changedDays.toString());
   }, [changedDays]);
 
   const moveToSelectedDate = () => {
-    router.push(`/day/${DayStorage(pivotDate.slice(0, 10), changedDays)}`);
+    const movedDate = DayStorage(STANDARD_DATE.slice(0, 10), changedDays);
+    router.push(`/day/${movedDate}`);
   };
 
   const moveToTheseDate = (count: number) => {

--- a/src/components/Day/DayInfoSection/DateView.tsx
+++ b/src/components/Day/DayInfoSection/DateView.tsx
@@ -3,17 +3,17 @@ import { theme } from 'src/styles/theme';
 import { DayStorage, makeDateString } from 'src/utils/getDate';
 import styled from 'styled-components';
 
-const CHANGED_DAYS_NUMBER = Number(window.sessionStorage.getItem('changedDaysCount')) || 0;
-const STANDARD_DATE = makeDateString(0);
-const CHANGED_DATE =
-  STANDARD_DATE !== null
-    ? DayStorage(STANDARD_DATE.slice(0, 10), CHANGED_DAYS_NUMBER)
-    : makeDateString(CHANGED_DAYS_NUMBER);
-const MONTH = CHANGED_DATE.slice(5, 7);
-const DATE = CHANGED_DATE.slice(8, 10);
-const DAY_OF_THE_WEEK = CHANGED_DATE.slice(11, 14);
-
 function DateView() {
+  const CHANGED_DAYS_NUMBER = Number(window.sessionStorage.getItem('changedDaysCount')) || 0;
+  const STANDARD_DATE = makeDateString(0);
+  const CHANGED_DATE =
+    STANDARD_DATE !== null
+      ? DayStorage(STANDARD_DATE.slice(0, 10), CHANGED_DAYS_NUMBER)
+      : makeDateString(CHANGED_DAYS_NUMBER);
+  const MONTH = CHANGED_DATE.slice(5, 7);
+  const DATE = CHANGED_DATE.slice(8, 10);
+  const DAY_OF_THE_WEEK = CHANGED_DATE.slice(11, 14);
+
   return (
     <Styled.Root>
       <Styled.HeaderBox>

--- a/src/components/Day/DayInfoSection/DateView.tsx
+++ b/src/components/Day/DayInfoSection/DateView.tsx
@@ -3,17 +3,17 @@ import { theme } from 'src/styles/theme';
 import { DayStorage, makeDateString } from 'src/utils/getDate';
 import styled from 'styled-components';
 
-function DateView() {
-  const changedDaysNumber = Number(window.localStorage.getItem('changedDaysCount'));
-  const pivotDate = window.localStorage.getItem('pivotDate');
-  const changedDate =
-    pivotDate !== null
-      ? DayStorage(pivotDate.slice(0, 10), changedDaysNumber)
-      : makeDateString(changedDaysNumber);
-  const MONTH = changedDate.slice(5, 7);
-  const DATE = changedDate.slice(8, 10);
-  const DAY_OF_THE_WEEK = changedDate.slice(11, 14);
+const CHANGED_DAYS_NUMBER = Number(window.sessionStorage.getItem('changedDaysCount')) || 0;
+const STANDARD_DATE = makeDateString(0);
+const CHANGED_DATE =
+  STANDARD_DATE !== null
+    ? DayStorage(STANDARD_DATE.slice(0, 10), CHANGED_DAYS_NUMBER)
+    : makeDateString(CHANGED_DAYS_NUMBER);
+const MONTH = CHANGED_DATE.slice(5, 7);
+const DATE = CHANGED_DATE.slice(8, 10);
+const DAY_OF_THE_WEEK = CHANGED_DATE.slice(11, 14);
 
+function DateView() {
   return (
     <Styled.Root>
       <Styled.HeaderBox>


### PR DESCRIPTION
## ✅ PR check list

- [x] PR 제목: "[#이슈번호] 작업 내용" 
- [x] commit message가 적절한지 확인해주세요.
- [x] 적절한 branch로 요청했는지 확인해주세요.
- [x] Assignees, Label을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer로 등록해주세요.

## 📝 PR 요약

- 로컬스토리지에 저장된`기준날짜(pivotDate)` 와 `변경된 날짜 카운트(changedDaysCount)`변수를 통해서 날짜의 상태를 관리하는 기존 로직에서 , 세션 스토리지에 `변경된 날짜 카운트(changedDaysCount)`만을 이용해서 종료시엔 당일 날짜로 돌아오고, 해당 탭 새로고침시에만 날짜가 저장되도록 구현하였습니다. 
- 전환 과정에서 불필요한 로직은 리팩토링하고, 일부 변수명을 수정했습니다.  
- 전역 상태를 사용하지 않고, 부모 컴포넌트에서 상태를 내려받지 않으면서 두 컴포넌트 간의 상태를 공유하는 것이 불가능하다보니, 날짜를 받아 표시하는`DateView`의 컴포넌트의 상태 관리방식이 다소 이상한데... 이부분을 어떻게 고치면 좋을지 고민을 해봐야겠습니다.

## 📌 변경 사항 및 주의 사항

```typescript
function DateView() {
  const CHANGED_DAYS_NUMBER = Number(window.sessionStorage.getItem('changedDaysCount')) || 0;
  const STANDARD_DATE = makeDateString(0);
  const CHANGED_DATE =
    STANDARD_DATE !== null
      ? DayStorage(STANDARD_DATE.slice(0, 10), CHANGED_DAYS_NUMBER)
      : makeDateString(CHANGED_DAYS_NUMBER);
  const MONTH = CHANGED_DATE.slice(5, 7);
  const DATE = CHANGED_DATE.slice(8, 10);
  const DAY_OF_THE_WEEK = CHANGED_DATE.slice(11, 14);

  return (
    <Styled.Root>
      <Styled.HeaderBox>
        <Styled.Month>{MONTH}</Styled.Month>
        <Styled.DayOfTheWeek>{DAY_OF_THE_WEEK}</Styled.DayOfTheWeek>
      </Styled.HeaderBox>
      <Styled.Day>{DATE}.</Styled.Day>
    </Styled.Root>
  );
}
```


![Mar-21-2023 21-36-28](https://user-images.githubusercontent.com/69416561/226611062-967e92e9-5470-4d9a-b20b-8bd10fa4aab0.gif)

